### PR TITLE
Integrate Cloudinary image uploads

### DIFF
--- a/server/.env
+++ b/server/.env
@@ -3,5 +3,10 @@ ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=securepassword123
 JWT_SECRET=supersecretjwtkey123
 
+# Cloudinary credentials
+CLOUDINARY_CLOUD_NAME=your_cloud_name
+CLOUDINARY_API_KEY=your_api_key
+CLOUDINARY_API_SECRET=your_api_secret
+
 
 

--- a/server/index.js
+++ b/server/index.js
@@ -2,7 +2,6 @@ const express = require("express");
 const mongoose = require("mongoose");
 const cors = require("cors");
 const dotenv = require("dotenv");
-const path = require("path");
 
 const PORT = process.env.PORT || 8000;
 
@@ -16,8 +15,7 @@ app.use(cors());
 // 🛡️ Middleware
 app.use(express.json());
 
-// 📁 Статик зурагны фолдер
-app.use("/uploads", express.static(path.join(__dirname, "uploads")));
+// 📁 Cloudinary зурагны URL ашиглах тул локал статик фолдер шаардлагагүй
 
 // 📦 Routes
 const menuRoutes = require("./routes/menu.routes");

--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,8 @@
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.15.1",
-    "multer": "^2.0.1"
+    "multer": "^2.0.1",
+    "cloudinary": "^1.40.0",
+    "multer-storage-cloudinary": "^4.0.0"
   }
 }

--- a/server/routes/menu.routes.js
+++ b/server/routes/menu.routes.js
@@ -1,20 +1,23 @@
 const express = require("express");
 const router = express.Router();
 const multer = require("multer");
-const path = require("path");
-const fs = require("fs");
+const cloudinary = require("cloudinary").v2;
+const { CloudinaryStorage } = require("multer-storage-cloudinary");
 const MenuItem = require("../models/menu.model");
 const verifyToken = require("../middlewares/verifyToken");
 
-// 🖼️ Зураг хадгалах тохиргоо
-const storage = multer.diskStorage({
-  destination: function (req, file, cb) {
-    const uploadPath = "uploads/";
-    if (!fs.existsSync(uploadPath)) fs.mkdirSync(uploadPath);
-    cb(null, uploadPath);
-  },
-  filename: function (req, file, cb) {
-    cb(null, Date.now() + path.extname(file.originalname));
+// 🖼️ Cloudinary тохиргоо
+cloudinary.config({
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET,
+});
+
+const storage = new CloudinaryStorage({
+  cloudinary,
+  params: {
+    folder: "uploads",
+    allowed_formats: ["jpg", "jpeg", "png", "gif"],
   },
 });
 const upload = multer({ storage });
@@ -59,7 +62,7 @@ router.post("/", verifyToken, upload.single("image"), async (req, res) => {
         : [],
       category,
       days: parsedDays,
-      image: req.file ? `/uploads/${req.file.filename}` : undefined,
+      image: req.file ? req.file.path : undefined,
     });
 
     const saved = await newItem.save();
@@ -79,7 +82,7 @@ router.put("/:id", verifyToken, upload.single("image"), async (req, res) => {
     const update = req.body;
 
     if (req.file) {
-      update.image = `/uploads/${req.file.filename}`;
+      update.image = req.file.path;
     }
 
     const updated = await MenuItem.findByIdAndUpdate(id, update, { new: true });


### PR DESCRIPTION
## Summary
- switch menu routes to use Cloudinary storage
- remove local uploads folder usage
- add Cloudinary packages
- document Cloudinary credentials in `.env`

## Testing
- `node index.js` *(fails: Cannot find module 'cloudinary')*

------
https://chatgpt.com/codex/tasks/task_e_684a88b938a08333972f440069425dd7