### PR TITLE
Add deployment config info and fix API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# Restaurant Menu Application
+
+This project contains a Next.js frontend (`client`) and an Express/MongoDB backend (`server`). It is configured to use Cloudinary for image uploads, MongoDB for data storage, and can be deployed with Vercel (frontend) and Render (backend).
+
+## Setup
+
+### Prerequisites
+- Node.js 18 or later
+- npm
+- Cloudinary account
+- MongoDB Atlas database
+- Accounts on [Vercel](https://vercel.com/) and [Render](https://render.com/) for deployment (optional)
+
+### Backend
+1. Copy `server/.env` and update the values:
+   ```bash
+   MONGO_URI=your_mongodb_connection
+   ADMIN_EMAIL=admin@example.com
+   ADMIN_PASSWORD=securepassword123
+   JWT_SECRET=supersecretjwtkey123
+
+   CLOUDINARY_CLOUD_NAME=your_cloud_name
+   CLOUDINARY_API_KEY=your_api_key
+   CLOUDINARY_API_SECRET=your_api_secret
+   ```
+2. Install dependencies:
+   ```bash
+   cd server
+   npm ci
+   ```
+3. Start the server locally:
+   ```bash
+   node index.js
+   ```
+   The API will run on port `8000` by default.
+4. When deploying to Render, set the same environment variables in the Render dashboard.
+
+### Frontend
+1. Copy `client/.env` and make sure `NEXT_PUBLIC_API_URL` points to your backend URL (local or Render):
+   ```bash
+   NEXT_PUBLIC_API_URL=https://your-backend-url.com/api
+   ```
+2. Install dependencies:
+   ```bash
+   cd client
+   npm ci
+   ```
+3. Run the development server:
+   ```bash
+   npm run dev
+   ```
+4. Deploy the `client` folder to Vercel and configure the `NEXT_PUBLIC_API_URL` environment variable there as well.
+
+## Notes
+- Image uploads are streamed directly to Cloudinary using memory storage and `streamifier`.
+- The repository includes some `node_modules` for convenience but running `npm ci` is recommended.

--- a/client/src/lib/api/menu.ts
+++ b/client/src/lib/api/menu.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 
-const API_URL = `https://restaurant-meni-1.onrender.com/api`;
+const API_URL =
+  process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api";
 
 // 🔑 Token авна
 const getAuthHeader = () => {

--- a/server/routes/menu.routes.js
+++ b/server/routes/menu.routes.js
@@ -1,9 +1,9 @@
 const express = require("express");
 const router = express.Router();
-const upload = require("../middlewares/multer"); // ✔️ Memory-based
-const cloudinary = require("../config/cloudinary.config"); // ✔️ Cloudinary config
+const multer = require("multer");
+const streamifier = require("streamifier");
+const cloudinary = require("../server/config/cloudinary.config");
 const MenuItem = require("../models/menu.model");
-const verifyToken = require("../middlewares/verifyToken");
 
 // 🖼️ Cloudinary тохиргоо
 cloudinary.config({
@@ -12,14 +12,7 @@ cloudinary.config({
   api_secret: process.env.CLOUDINARY_API_SECRET,
 });
 
-const storage = new CloudinaryStorage({
-  cloudinary,
-  params: {
-    folder: "uploads",
-    allowed_formats: ["jpg", "jpeg", "png", "gif"],
-  },
-});
-const upload = multer({ storage });
+const upload = multer({ storage: multer.memoryStorage() });
 
 /**
  * ✅ GET - бүх хоол


### PR DESCRIPTION
## Summary
- update Cloudinary routes to use memory storage
- make frontend API base URL configurable
- document environment setup for Render and Vercel

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` in server *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684aa7a860508333ba0f45affdb45fb4