### PR TITLE
Fix Cloudinary image display

### DIFF
--- a/client/src/components/admin/MenuList.tsx
+++ b/client/src/components/admin/MenuList.tsx
@@ -23,7 +23,7 @@ export default function MenuList({ menus, onEdit, onRefresh }: Props) {
           >
             {menu.image && (
               <img
-                src={`http://localhost:8000${menu.image}`}
+                src={menu.image}
                 alt={menu.name}
                 className="w-full h-40 object-cover rounded mb-2"
               />

--- a/client/src/components/homepage/FoodCard.tsx
+++ b/client/src/components/homepage/FoodCard.tsx
@@ -19,9 +19,7 @@ export default function FoodCard({ item, onClick }: Props) {
     >
       {/* 🖼 Image */}
       <img
-        src={
-          item.image ? `http://localhost:8000${item.image}` : "/fallback.png"
-        }
+          src={item.image || "/fallback.png"}
         alt={item.name}
         className="w-full h-44 object-cover rounded-xl mb-4 shadow-sm"
       />

--- a/client/src/components/homepage/FoodDialog.tsx
+++ b/client/src/components/homepage/FoodDialog.tsx
@@ -26,11 +26,7 @@ export default function FoodDialog({ food, onClose }: Props) {
             </DialogHeader>
 
             <img
-              src={
-                food.image
-                  ? `http://localhost:8000${food.image}`
-                  : "/fallback.png"
-              }
+              src={food.image || "/fallback.png"}
               alt={food.name}
               className="w-full h-48 object-cover rounded-xl mb-4"
             />

--- a/client/src/components/homepage/MenuSection.tsx
+++ b/client/src/components/homepage/MenuSection.tsx
@@ -36,7 +36,7 @@ export default function MenuSection({
               className="bg-gradient-to-br from-amber-50 to-yellow-100 text-zinc-800 p-5 rounded-2xl shadow-xl border border-yellow-200 cursor-pointer transition-all duration-300"
             >
               <img
-                src={`http://localhost:8000${item.image}`}
+                src={item.image || "/fallback.png"}
                 alt={item.name}
                 className="w-full h-44 object-cover rounded-xl mb-4 shadow"
               />


### PR DESCRIPTION
## Summary
- use returned Cloudinary URL without localhost prefix

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aec8bc18c83339f256162185bcfb0